### PR TITLE
feat: add Julia to allowed base images

### DIFF
--- a/general/container-allowed-images/constraint.yaml
+++ b/general/container-allowed-images/constraint.yaml
@@ -71,6 +71,8 @@ spec:
       - 'library/bash'
       - 'python:'
       - 'library/python'
+      - 'julia:'
+      - 'library/julia'
       - 'sha256:'
       - 'library/sha256'
       - 'busybox'


### PR DESCRIPTION
Adds the base [julia](https://hub.docker.com/_/julia) images