### PR TITLE
feat(container-allowed-images): add new location for Kubecost

### DIFF
--- a/general/container-allowed-images/constraint.yaml
+++ b/general/container-allowed-images/constraint.yaml
@@ -124,6 +124,7 @@ spec:
       # Kubecost
       - 'gcr.io/kubecost1/'
       - 'jimmidyson/configmap-reload:'
+      - 'quay.io/kubecost1/checks'
 
       # Kubeflow
       - 'gcr.io/arrikto/kubeflow/'


### PR DESCRIPTION
Add a new location for the kubecost container used in cost-analyzer jobs.