### PR TITLE
feat(opa): Prometheus Operator container allowed images

### DIFF
--- a/general/container-allowed-images/constraint.yaml
+++ b/general/container-allowed-images/constraint.yaml
@@ -97,6 +97,9 @@ spec:
       - 'kiwigrid/k8s-sidecar'
       - 'quay.io/coreos/'
       - 'quay.io/prometheus/'
+      - 'jettech/kube-webhook-certgen'
+      - 'docker.io/jimmidyson/configmap-reload'
+      - 'squareup/ghostunnel'
 
       # Cert manager
       - 'quay.io/jetstack/'


### PR DESCRIPTION
A quick fix to get the Prometheus Operator working. I will later review if these can be proxied through Artifactory instead, or are necessary to begin with (e.g. ghostunnel seems to be only in the deprecated prometheus-operator chart and not the newer kube-stack-prometheus chart).