### PR TITLE
Adding miniconda image to allowed images

### DIFF
--- a/general/container-allowed-images/constraint.yaml
+++ b/general/container-allowed-images/constraint.yaml
@@ -72,6 +72,7 @@ spec:
       - 'library/bash'
       - 'python:'
       - 'library/python'
+      - 'continuumio/miniconda'
       - 'julia:'
       - 'library/julia'
       - 'sha256:'

--- a/general/container-allowed-images/constraint.yaml
+++ b/general/container-allowed-images/constraint.yaml
@@ -72,7 +72,7 @@ spec:
       - 'library/bash'
       - 'python:'
       - 'library/python'
-      - 'continuumio/miniconda'
+      - 'continuumio/miniconda3'
       - 'julia:'
       - 'library/julia'
       - 'sha256:'


### PR DESCRIPTION
__Note:__ this is my first PR here, so please let me know if you need additional information.

__Description:__ including [continuumio/miniconda3](https://hub.docker.com/r/continuumio/miniconda3) in the set of approved base images.

__Reason:__ many data scientists make use of ```conda``` to manage dependencies and virtual environments.