### PR TITLE
Add alpine (no ":") to whitelist

### DIFF
--- a/general/container-allowed-images/constraint.yaml
+++ b/general/container-allowed-images/constraint.yaml
@@ -66,6 +66,7 @@ spec:
       - 'kairen/rotate-elasticsearch-index'
 
       # Base containers
+      - 'alpine'
       - 'alpine:'
       - 'library/alpine'
       - 'bash:'


### PR DESCRIPTION
Some reusable kubeflow pipeline components use unpinned alpine