### PR TITLE
fix: add missing type to templates

### DIFF
--- a/general/pod-enforce-labels/template.yaml
+++ b/general/pod-enforce-labels/template.yaml
@@ -11,6 +11,7 @@ spec:
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:
+          type: object
           properties:
             labels:
               type: array

--- a/pod-security-policy/allowed-external-ips/template.yaml
+++ b/pod-security-policy/allowed-external-ips/template.yaml
@@ -11,6 +11,7 @@ spec:
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:
+          type: object
           properties:
             allowedIPs:
               type: array

--- a/pod-security-policy/enforce-apparmor-profile/template.yaml
+++ b/pod-security-policy/enforce-apparmor-profile/template.yaml
@@ -25,6 +25,7 @@ spec:
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:
+          type: object
           properties:
             allowedProfiles:
               type: array

--- a/service-mesh/port-naming/template.yaml
+++ b/service-mesh/port-naming/template.yaml
@@ -24,6 +24,7 @@ spec:
         kind: AllowedServicePortName
       validation:
         openAPIV3Schema:
+          type: object
           properties:
             prefixes:
               type: array


### PR DESCRIPTION
@zachomedia  I think this will resolve these errors

![Screenshot from 2021-09-09 19-45-41](https://user-images.githubusercontent.com/10801138/132776719-25c46169-823a-4de5-9210-59e72974dbcd.png)

Just based on other working templates
![Screenshot from 2021-09-09 19-46-42](https://user-images.githubusercontent.com/10801138/132776788-7cbe5f96-44c2-4562-87b7-c42c59350c8a.png)


