### PR TITLE
DRAFT: Deny User Specified Tolerations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .cache
 .env
+
+*constraint.yaml

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ We recommend installing the following software locally to test your rego policie
 
 ## How to Contribute
 
+> TODO: update with Taskfile commands once it is set up
+
 1. Create a folder in this repository with a semantically meaningful name (i.e. it should be clear from the name what the policy relates to). Additionally, you should place your policy under the broader category that it relates to (e.g. `pod-security-policy`).
 2. In your folder, create a file called `src.rego`. Structure your `src.rego` file in the way shown below; this allows `ConstraintTemplates` and `Constraints` to be automatically generated from your rego policy.
 
@@ -57,7 +59,9 @@ test_short_description_of_what_this_is_testing {
 }
 ```
 
-4.
+4. Run `opa test -v .` to test (in verbose mode) the rego policy in the current directory. The output will indicate whether all of the opa unit tests are passing.
+5. Run `konstraint create src.rego --skip-constraints` to auto-generate the `template.yaml` file containing the `ConstraintTemplate` for the current Gatekeeper policy.
+6. Run `konstraint doc src.rego --output README.md` to auto-generate documentation for the current Gatekeeper policy.
 
 ## General
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ test_short_description_of_what_this_is_testing {
 ```
 
 4. Run `opa test -v .` to test (in verbose mode) the rego policy in the current directory. The output will indicate whether all of the opa unit tests are passing.
-5. Run `konstraint create src.rego --skip-constraints` to auto-generate the `template.yaml` file containing the `ConstraintTemplate` for the current Gatekeeper policy.
+5. Run `konstraint create src.rego` to auto-generate the `template.yaml` and `constraint.yaml` files containing the `ConstraintTemplate` and `Constraint` for the current Gatekeeper policy. Note that `*constraint.yaml` is in the `.gitignore` at
 6. Run `konstraint doc src.rego --output README.md` to auto-generate documentation for the current Gatekeeper policy.
 
 ## General

--- a/README.md
+++ b/README.md
@@ -1,8 +1,63 @@
 # GateKeeper Policies
 
-Policies that are to be enforced by [GateKeeper](https://github.com/open-policy-agent/gatekeeper) for the Kubernetes Platform.
+![Kubernetes Admission Controllers Diagram](https://d33wubrfki0l68.cloudfront.net/af21ecd38ec67b3d81c1b762221b4ac777fcf02d/7c60e/images/blog/2019-03-21-a-guide-to-kubernetes-admission-controllers/admission-controller-phases.png)
 
-> Note: Gatekeeper is a validating / mutating webhook that enforces CRD-based policies executed by the Open Policy Agent.
+Recall that there are two kinds of admission control webhooks in Kubernetes: (1) mutating admission webhooks, and (2) validating admission webhooks.[^1] [Gatekeeper](https://kubernetes.io/blog/2019/08/06/opa-gatekeeper-policy-and-governance-for-kubernetes/) is a **validating admission webhook** that enforces policies executed by [Open Policy Agent (OPA)](https://www.openpolicyagent.org).
+
+[^1] Diagram borrowed from [Kubernetes Admission Controllers Documentation](https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/)
+
+This repository contains policies that are enforced by [GateKeeper](https://github.com/open-policy-agent/gatekeeper) for the Kubernetes Platform.
+
+## Prerequisites
+
+We recommend installing the following software locally to test your rego policies.
+
+- [Open Policy Agent](https://www.openpolicyagent.org/docs/v0.11.0/get-started/)
+- [Konstraint](https://github.com/plexsystems/konstraint)
+
+## How to Contribute
+
+1. Create a folder in this repository with a semantically meaningful name (i.e. it should be clear from the name what the policy relates to). Additionally, you should place your policy under the broader category that it relates to (e.g. `pod-security-policy`).
+2. In your folder, create a file called `src.rego`. Structure your `src.rego` file in the way shown below; this allows `ConstraintTemplates` and `Constraints` to be automatically generated from your rego policy.
+
+```rego
+# @title <title of your policy>
+#
+# Written description of your policy
+#
+# @enforcement deny # Can be either "deny" or "dryrun"
+# @kinds <group/resource type that the constraint applies to>
+package <name of rego policy>
+
+
+violation[{"msg": msg, "details": {}}] {
+    # Business logic of rego policy goes here
+}
+```
+
+3. Create a file called `src_test.rego` that contains one or more unit tests written against the policy defined in `src.rego`. The test code should be structured as follows (roughly). Note that you would either indicate `count(results) > 0` if you *expect* a violation **or** `count(results) == 0` if you *do not expect* a violation.
+
+```rego
+package deny_user_pod_system_node
+
+# Include a short description of what this test case is verifying.
+test_short_description_of_what_this_is_testing {
+	input := {
+        # Your input spec goes here
+    }
+
+	# Evaluate the violation with the input
+	results := violation with input as input
+
+	# Expect a violation
+	count(results) > 0
+
+    # Do not expect a violation
+    count(results) == 0
+}
+```
+
+4.
 
 ## General
 
@@ -13,7 +68,7 @@ This repo contains general policies that can be used to enforce common Kubernete
 | Container Allowed Images         | [container-allowed-images](general/container-allowed-images)                 |
 | Container Image Must Have Digest | [container-image-must-have-digest](general/container-image-must-have-digest) |
 | Container Limits                 | [container-limits](general/container-limits)                                 |
-| Deny External Users              | [deny-external-users](general/deny-external-users)                                 |
+| Deny External Users              | [deny-external-users](general/deny-external-users)                           |
 | Ingress No Hostnames             | [ingress-no-hostnames](general/ingress-no-hostnames)                         |
 | Ingress Hostnames Conflict       | [ingress-hostnames-conflict](general/ingress-hostnames-conflict)             |
 | Load Balancer No Public IPs      | [loadbalancer-no-public-ips](general/loadbalancer-no-public-ips)             |
@@ -62,6 +117,7 @@ This repo contains a set of common policies that can be used to enforce specific
 | Port Naming         | [port-naming](service-mesh/port-naming)                 |
 | Traffic Policy      | [traffic-policy](service-mesh/traffic-policy)           |
 
+
 ## Links
 
 - [Rego Playground](https://play.openpolicyagent.org/)
@@ -72,3 +128,4 @@ This repo contains a set of common policies that can be used to enforce specific
 - [Azure Policy](https://github.com/Azure/azure-policy/tree/master/built-in-references/Kubernetes)
 - [Community Policy](https://github.com/Azure/Community-Policy)
 - [Open Policy Agent](https://github.com/open-policy-agent/gatekeeper-library)
+

--- a/pod-security-policy/deny-user-specified-tolerations/.gitignore
+++ b/pod-security-policy/deny-user-specified-tolerations/.gitignore
@@ -1,0 +1,1 @@
+constraints/

--- a/pod-security-policy/deny-user-specified-tolerations/.gitignore
+++ b/pod-security-policy/deny-user-specified-tolerations/.gitignore
@@ -1,1 +1,0 @@
-constraints/

--- a/pod-security-policy/deny-user-specified-tolerations/README.md
+++ b/pod-security-policy/deny-user-specified-tolerations/README.md
@@ -1,0 +1,121 @@
+# Policies
+
+## Violations
+
+* [Deny pods from being scheduled to inappropriate nodes](#deny-pods-from-being-scheduled-to-inappropriate-nodes)
+
+## Deny pods from being scheduled to inappropriate nodes
+
+**Severity:** Violation
+
+**Resources:** core/Pod
+
+A number of user-specified tolerations should be rejected as these
+tolerations can be used to schedule a user pod to an inappropriate node pool.
+In particular, the following scenarios need to be checked:
+1. If a user pod (i.e. namespace != "system") is submitted with the toleration
+`node.statcan.gc.ca/purpose=system:NoSchedule`, then the request must be denied
+as the user pod may be scheduled onto a system nodepool.
+2. If an **unclassified** user pod (i.e. a pod without the label `data.statcan.gc.ca/classification: protected-b`)
+is submitted with the toleration `data.statcan.gc.ca/classification=protected-b:NoSchedule`, then the
+request must be denied as an unclassified pod may be scheduled onto a protected-b nodepool.
+3. If a **protected-b** user pod (i.e. a pod with the label `data.statcan.gc.ca/classification: protected-b`)
+is submitted with the toleration `data.statcan.gc.ca/classification=unclassified:NoSchedule`, then the
+request must be denied as a protected-b pod may be scheduled onto an unclassified nodepool.
+
+## Test Cases
+1. If a pod is submitted from a **non-system namespace** and contains a toleration
+allowing it to be scheduled to a **system node**, then the request should be **denied**.
+2. If a pod is submitted from a **system namespace** and it contains a toleration
+allowing it to be scheduled to a **system node**, then the request should be **allowed**.
+3. If a pod is submitted from a **daaas namespace** and it contains a toleration
+allowing it to be scheduled to a **system node**, then the request should be **allowed**.
+4. If an **unclassified pod** is submitted from a **user namespace** and it contains a toleration
+allowing it to be scheduled to a **protected-b node**, then the request should be **denied**.
+5. If a **protected-b pod** is submitted from a **user namespace**, and it contains a toleration
+allowing it to be scheduled to a **protected-b node**, then the request should be **allowed**.
+6. If a **protected-b pod** is submitted from a **user namespace** and it contains a toleration
+allowing it to be scheduled to an **unclassified node**, then the request should be **denied**.
+7. If an **unclassified pod** is submitted from a **user namespace**, and it contains a toleration
+allowing it to be scheduled to an **unclassified node**, then the request should be **allowed**.
+
+### Rego
+
+```rego
+package deny_user_pod_system_node
+
+system_namespace_label = "namespace.statcan.gc.ca/purpose"
+system_namespace = ["system", "daaas"]
+
+classification_label = "data.statcan.gc.ca/classification"
+
+is_system_namespace(pod) {
+  # Get the namespace object that the pod belongs to
+  namespace := data.inventory.cluster["namespace"][pod.metadata.namespace]
+  # Note: can also access namespaced resources this way, e.g.
+  # data.inventory.namespace["your namespace"].rolebindings["myrolebinding"]...
+
+  # If the namespace has purpose "system", then this policy does not apply.
+  ns := namespace.metadata.labels[system_namespace_label]
+  count([system | system := system_namespace[_]; system == ns]) > 0
+}
+
+
+violation[{"msg": msg, "details": {}}] {
+  resource := input.review.object
+
+  # Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+  purpose_toleration := resource.spec.tolerations[_]
+  purpose_toleration["key"] == system_namespace_label
+  purpose_toleration["value"] == "system"
+
+  not is_system_namespace(resource)
+
+  # Get pod name and namespace
+  pod_name := resource.metadata.name
+  namespace := resource.metadata.namespace
+  msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
+}
+
+violation[{"msg": msg, "details": {}}] {
+  resource := input.review.object
+
+  # Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+  purpose_toleration := resource.spec.tolerations[_]
+  purpose_toleration["key"] == classification_label
+  purpose_toleration["value"] == "protected-b"
+
+  # Check if classification label is absent or unclassified, this pod must not go to a protected-b node pool
+  not resource.metadata.labels[classification_label] == "protected-b"
+
+  not is_system_namespace(resource)
+
+
+  # Get pod name and namespace
+  pod_name := resource.metadata.name
+  namespace := resource.metadata.namespace
+  msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to a protected-b node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
+}
+
+violation[{"msg": msg, "details": {}}] {
+  resource := input.review.object
+
+  # Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+  purpose_toleration := resource.spec.tolerations[_]
+  purpose_toleration["key"] == classification_label
+  purpose_toleration["value"] == "unclassified"
+
+  # Check if classification label is absent or unclassified, this pod must not go to a protected-b node pool
+  resource.metadata.labels[classification_label] == "protected-b"
+
+  not is_system_namespace(resource)
+
+
+  # Get pod name and namespace
+  pod_name := resource.metadata.name
+  namespace := resource.metadata.namespace
+  msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to an unclassified node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
+}
+```
+
+_source: [.](.)_

--- a/pod-security-policy/deny-user-specified-tolerations/kustomization.yaml
+++ b/pod-security-policy/deny-user-specified-tolerations/kustomization.yaml
@@ -1,0 +1,12 @@
+# ----------------------------------------------------
+# apiVersion and kind of Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Each entry in this list must resolve to an existing
+# resource definition in YAML.  These are the resource
+# files that kustomize reads, modifies and emits as a
+# YAML string, with resources separated by document
+# markers ("---").
+resources:
+  - template.yaml

--- a/pod-security-policy/deny-user-specified-tolerations/src.rego
+++ b/pod-security-policy/deny-user-specified-tolerations/src.rego
@@ -1,0 +1,94 @@
+# @title Deny user pod from being scheduled to system nodes
+#
+# A number of user-specified tolerations should be rejected as these
+# tolerations can be used to schedule a user pod to an inappropriate node pool.
+# In particular, the following scenarios need to be checked:
+
+# 1. If a user pod (i.e. namespace != "system") is submitted with the toleration
+#    `node.statcan.gc.ca/purpose=system:NoSchedule`, then the request must be denied
+#    as the user pod may be scheduled onto a system nodepool.
+# 2. If an **unclassified** user pod (i.e. a pod without the label `data.statcan.gc.ca/classification: protected-b`)
+#    is submitted with the toleration `data.statcan.gc.ca/classification=protected-b:NoSchedule`, then the
+#    request must be denied as an unclassified pod may be scheduled onto a protected-b nodepool.
+# 3. If a **protected-b** user pod (i.e. a pod with the label `data.statcan.gc.ca/classification: protected-b`)
+#    is submitted with the toleration `data.statcan.gc.ca/classification=unclassified:NoSchedule`, then the
+#    request must be denied as a protected-b pod may be scheduled onto an unclassified nodepool.
+#
+# @enforcement deny
+# @kinds core/Pod
+package deny_user_pod_system_node
+
+system_namespace := "system"
+
+violation[{"msg": msg, "details": {}}] {
+	resource := input.review.object
+
+	# Tolerate scheduling user pod to system node is forbidden
+	forbidden_toleration := {
+		"effect": "NoSchedule",
+		"key": "node.statcan.gc.ca/purpose",
+		"operator": "Equal",
+		"value": "system",
+	}
+
+	# If the namespace is "system", then this policy does not apply.
+	resource.metadata.namespace != system_namespace
+
+	# If the forbidden toleration is not present, then this policy does not apply.
+	tolerations := [toleration | resource.spec.tolerations[i] == forbidden_toleration; toleration := resource.spec.tolerations[i]]
+	count(tolerations) > 0
+
+	# Get pod name and namespace
+	pod_name := resource.metadata.name
+	namespace := resource.metadata.namespace
+	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %v, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, forbidden_toleration])
+}
+
+
+violation[{"msg": msg, "details": {}}] {
+	resource := input.review.object
+
+	# Tolerate scheduling user pod to system node is forbidden
+	forbidden_toleration := {
+		"effect": "NoSchedule",
+		"key": "data.statcan.gc.ca/classification",
+		"operator": "Equal",
+		"value": "protected-b",
+	}
+
+	# If the namespace is "system", then this policy does not apply.
+	resource.metadata.namespace != system_namespace
+
+	# If the forbidden toleration is not present, then this policy does not apply.
+	tolerations := [toleration | resource.spec.tolerations[i] == forbidden_toleration; toleration := resource.spec.tolerations[i]]
+	count(tolerations) > 0
+
+	# Get pod name and namespace
+	pod_name := resource.metadata.name
+	namespace := resource.metadata.namespace
+	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %v, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, forbidden_toleration])
+}
+
+violation[{"msg": msg, "details": {}}] {
+	resource := input.review.object
+
+	# Tolerate scheduling user pod to system node is forbidden
+	forbidden_toleration := {
+		"effect": "NoSchedule",
+		"key": "node.statcan.gc.ca/purpose",
+		"operator": "Equal",
+		"value": "system",
+	}
+
+	# If the namespace is "system", then this policy does not apply.
+	resource.metadata.namespace != system_namespace
+
+	# If the forbidden toleration is not present, then this policy does not apply.
+	tolerations := [toleration | resource.spec.tolerations[i] == forbidden_toleration; toleration := resource.spec.tolerations[i]]
+	count(tolerations) > 0
+
+	# Get pod name and namespace
+	pod_name := resource.metadata.name
+	namespace := resource.metadata.namespace
+	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %v, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, forbidden_toleration])
+}

--- a/pod-security-policy/deny-user-specified-tolerations/src.rego
+++ b/pod-security-policy/deny-user-specified-tolerations/src.rego
@@ -1,4 +1,4 @@
-# @title Deny user pod from being scheduled to system nodes
+# @title Deny pods from being scheduled to inappropriate nodes
 #
 # A number of user-specified tolerations should be rejected as these
 # tolerations can be used to schedule a user pod to an inappropriate node pool.
@@ -14,81 +14,95 @@
 #    is submitted with the toleration `data.statcan.gc.ca/classification=unclassified:NoSchedule`, then the
 #    request must be denied as a protected-b pod may be scheduled onto an unclassified nodepool.
 #
+# ## Test Cases
+# 1. If a pod is submitted from a **non-system namespace** and contains a toleration
+#    allowing it to be scheduled to a **system node**, then the request should be **denied**.
+# 2. If a pod is submitted from a **system namespace** and it contains a toleration
+#    allowing it to be scheduled to a **system node**, then the request should be **allowed**.
+# 3. If a pod is submitted from a **daaas namespace** and it contains a toleration
+#    allowing it to be scheduled to a **system node**, then the request should be **allowed**.
+# 4. If an **unclassified pod** is submitted from a **user namespace** and it contains a toleration
+#    allowing it to be scheduled to a **protected-b node**, then the request should be **denied**.
+# 5. If a **protected-b pod** is submitted from a **user namespace**, and it contains a toleration
+#    allowing it to be scheduled to a **protected-b node**, then the request should be **allowed**.
+# 6. If a **protected-b pod** is submitted from a **user namespace** and it contains a toleration
+#    allowing it to be scheduled to an **unclassified node**, then the request should be **denied**.
+# 7. If an **unclassified pod** is submitted from a **user namespace**, and it contains a toleration
+#    allowing it to be scheduled to an **unclassified node**, then the request should be **allowed**.
+#
 # @enforcement deny
 # @kinds core/Pod
 package deny_user_pod_system_node
 
-system_namespace := "system"
+system_namespace_label = "namespace.statcan.gc.ca/purpose"
+system_namespace = ["system", "daaas"]
 
-violation[{"msg": msg, "details": {}}] {
-	resource := input.review.object
+classification_label = "data.statcan.gc.ca/classification"
 
-	# Tolerate scheduling user pod to system node is forbidden
-	forbidden_toleration := {
-		"effect": "NoSchedule",
-		"key": "node.statcan.gc.ca/purpose",
-		"operator": "Equal",
-		"value": "system",
-	}
+is_system_namespace(pod) {
+	# Get the namespace object that the pod belongs to
+	namespace := data.inventory.cluster["namespace"][pod.metadata.namespace]
+	# Note: can also access namespaced resources this way, e.g.
+	# data.inventory.namespace["your namespace"].rolebindings["myrolebinding"]...
 
-	# If the namespace is "system", then this policy does not apply.
-	resource.metadata.namespace != system_namespace
-
-	# If the forbidden toleration is not present, then this policy does not apply.
-	tolerations := [toleration | resource.spec.tolerations[i] == forbidden_toleration; toleration := resource.spec.tolerations[i]]
-	count(tolerations) > 0
-
-	# Get pod name and namespace
-	pod_name := resource.metadata.name
-	namespace := resource.metadata.namespace
-	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %v, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, forbidden_toleration])
+	# If the namespace has purpose "system", then this policy does not apply.
+	ns := namespace.metadata.labels[system_namespace_label]
+	count([system | system := system_namespace[_]; system == ns]) > 0
 }
 
 
 violation[{"msg": msg, "details": {}}] {
 	resource := input.review.object
 
-	# Tolerate scheduling user pod to system node is forbidden
-	forbidden_toleration := {
-		"effect": "NoSchedule",
-		"key": "data.statcan.gc.ca/classification",
-		"operator": "Equal",
-		"value": "protected-b",
-	}
+	# Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+	purpose_toleration := resource.spec.tolerations[_]
+	purpose_toleration["key"] == system_namespace_label
+	purpose_toleration["value"] == "system"
 
-	# If the namespace is "system", then this policy does not apply.
-	resource.metadata.namespace != system_namespace
-
-	# If the forbidden toleration is not present, then this policy does not apply.
-	tolerations := [toleration | resource.spec.tolerations[i] == forbidden_toleration; toleration := resource.spec.tolerations[i]]
-	count(tolerations) > 0
+	not is_system_namespace(resource)
 
 	# Get pod name and namespace
 	pod_name := resource.metadata.name
 	namespace := resource.metadata.namespace
-	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %v, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, forbidden_toleration])
+	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
 }
 
 violation[{"msg": msg, "details": {}}] {
 	resource := input.review.object
 
-	# Tolerate scheduling user pod to system node is forbidden
-	forbidden_toleration := {
-		"effect": "NoSchedule",
-		"key": "node.statcan.gc.ca/purpose",
-		"operator": "Equal",
-		"value": "system",
-	}
+	# Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+	purpose_toleration := resource.spec.tolerations[_]
+	purpose_toleration["key"] == classification_label
+	purpose_toleration["value"] == "protected-b"
 
-	# If the namespace is "system", then this policy does not apply.
-	resource.metadata.namespace != system_namespace
+	# Check if classification label is absent or unclassified, this pod must not go to a protected-b node pool
+	not resource.metadata.labels[classification_label] == "protected-b"
 
-	# If the forbidden toleration is not present, then this policy does not apply.
-	tolerations := [toleration | resource.spec.tolerations[i] == forbidden_toleration; toleration := resource.spec.tolerations[i]]
-	count(tolerations) > 0
+	not is_system_namespace(resource)
+
 
 	# Get pod name and namespace
 	pod_name := resource.metadata.name
 	namespace := resource.metadata.namespace
-	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %v, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, forbidden_toleration])
+	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to a protected-b node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
+}
+
+violation[{"msg": msg, "details": {}}] {
+	resource := input.review.object
+
+	# Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+	purpose_toleration := resource.spec.tolerations[_]
+	purpose_toleration["key"] == classification_label
+	purpose_toleration["value"] == "unclassified"
+
+	# Check if classification label is absent or unclassified, this pod must not go to a protected-b node pool
+	resource.metadata.labels[classification_label] == "protected-b"
+
+	not is_system_namespace(resource)
+
+
+	# Get pod name and namespace
+	pod_name := resource.metadata.name
+	namespace := resource.metadata.namespace
+	msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to an unclassified node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
 }

--- a/pod-security-policy/deny-user-specified-tolerations/src.rego
+++ b/pod-security-policy/deny-user-specified-tolerations/src.rego
@@ -3,7 +3,7 @@
 # A number of user-specified tolerations should be rejected as these
 # tolerations can be used to schedule a user pod to an inappropriate node pool.
 # In particular, the following scenarios need to be checked:
-
+#
 # 1. If a user pod (i.e. namespace != "system") is submitted with the toleration
 #    `node.statcan.gc.ca/purpose=system:NoSchedule`, then the request must be denied
 #    as the user pod may be scheduled onto a system nodepool.

--- a/pod-security-policy/deny-user-specified-tolerations/src_test.rego
+++ b/pod-security-policy/deny-user-specified-tolerations/src_test.rego
@@ -1,14 +1,24 @@
 package deny_user_pod_system_node
 
-# If a user pod is submitted from a non-system namespace and contains a
-# toleration allowing it to be scheduled to a system node, then the
-# request should be denied.
+
 test_user_pod_with_system_node_toleration_is_violation {
+	cluster := {
+		"namespace": {
+			"user-namespace": {
+				"metadata": {
+					"labels": {
+						"namespace.statcan.gc.ca/purpose": ""
+					}
+				}
+			}
+		}
+	}
+
 	input := {"review": {"object": {
 		"kind": "Pod",
 		"metadata": {
 			"name": "user-pod",
-			"namespace": "default",
+			"namespace": "user-namespace",
 			"labels": {"app": "user-pod"},
 		},
 		"spec": {
@@ -29,19 +39,19 @@ test_user_pod_with_system_node_toleration_is_violation {
 			"tolerations": [
 				{
 					"effect": "NoSchedule",
-					"key": "classification",
+					"key": "data.statcan.gc.ca/classification",
 					"operator": "Equal",
 					"value": "sensitive",
 				},
 				{
 					"effect": "NoSchedule",
-					"key": "purpose",
+					"key": "namespace.statcan.gc.ca/purpose",
 					"operator": "Equal",
 					"value": "system",
 				},
 				{
 					"effect": "NoSchedule",
-					"key": "use",
+					"key": "node.statcan.gc.ca/use",
 					"operator": "Equal",
 					"value": "general",
 				},
@@ -50,8 +60,140 @@ test_user_pod_with_system_node_toleration_is_violation {
 	}}}
 
 	# Evaluate the violation with the input
-	results := violation with input as input
+	results := violation with input as input with data.inventory.cluster as cluster
 
 	# Expect a violation
 	count(results) > 0
+}
+
+
+test_system_pod_with_system_node_toleration_is_not_violation {
+	cluster := {
+		"namespace": {
+			"system": {
+				"metadata": {
+					"labels": {
+						"namespace.statcan.gc.ca/purpose": "daaas"
+					}
+				}
+			}
+		}
+	}
+
+	input := {"review": {"object": {
+		"kind": "Pod",
+		"metadata": {
+			"name": "system-pod",
+			"namespace": "system",
+			"labels": {"app": "system-pod"},
+		},
+		"spec": {
+			"containers": [{
+				"name": "system-pod",
+				"image": "nginx:latest",
+				"resources": {
+					"limits": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+					"requests": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+				},
+			}],
+			"tolerations": [
+				{
+					"effect": "NoSchedule",
+					"key": "data.statcan.gc.ca/classification",
+					"operator": "Equal",
+					"value": "sensitive",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "namespace.statcan.gc.ca/purpose",
+					"operator": "Equal",
+					"value": "system",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "node.statcan.gc.ca/use",
+					"operator": "Equal",
+					"value": "general",
+				},
+			],
+		},
+	}}}
+
+	# Evaluate the violation with the input
+	results := violation with input as input with data.inventory.cluster as cluster
+
+	# Do not expect a violation
+	count(results) == 0
+}
+
+
+test_daaas_pod_with_system_node_toleration_is_not_violation {
+	cluster := {
+		"namespace": {
+			"system": {
+				"metadata": {
+					"labels": {
+						"namespace.statcan.gc.ca/purpose": "system"
+					}
+				}
+			}
+		}
+	}
+
+	input := {"review": {"object": {
+		"kind": "Pod",
+		"metadata": {
+			"name": "system-pod",
+			"namespace": "system",
+			"labels": {"app": "system-pod"},
+		},
+		"spec": {
+			"containers": [{
+				"name": "system-pod",
+				"image": "nginx:latest",
+				"resources": {
+					"limits": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+					"requests": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+				},
+			}],
+			"tolerations": [
+				{
+					"effect": "NoSchedule",
+					"key": "data.statcan.gc.ca/classification",
+					"operator": "Equal",
+					"value": "sensitive",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "namespace.statcan.gc.ca/purpose",
+					"operator": "Equal",
+					"value": "system",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "node.statcan.gc.ca/use",
+					"operator": "Equal",
+					"value": "general",
+				},
+			],
+		},
+	}}}
+
+	# Evaluate the violation with the input
+	results := violation with input as input with data.inventory.cluster as cluster
+
+	# Do not expect a violation
+	count(results) == 0
 }

--- a/pod-security-policy/deny-user-specified-tolerations/src_test.rego
+++ b/pod-security-policy/deny-user-specified-tolerations/src_test.rego
@@ -41,7 +41,7 @@ test_user_pod_with_system_node_toleration_is_violation {
 					"effect": "NoSchedule",
 					"key": "data.statcan.gc.ca/classification",
 					"operator": "Equal",
-					"value": "sensitive",
+					"value": "protected-b",
 				},
 				{
 					"effect": "NoSchedule",
@@ -107,7 +107,7 @@ test_system_pod_with_system_node_toleration_is_not_violation {
 					"effect": "NoSchedule",
 					"key": "data.statcan.gc.ca/classification",
 					"operator": "Equal",
-					"value": "sensitive",
+					"value": "protected-b",
 				},
 				{
 					"effect": "NoSchedule",
@@ -173,13 +173,253 @@ test_daaas_pod_with_system_node_toleration_is_not_violation {
 					"effect": "NoSchedule",
 					"key": "data.statcan.gc.ca/classification",
 					"operator": "Equal",
-					"value": "sensitive",
+					"value": "protected-b",
 				},
 				{
 					"effect": "NoSchedule",
 					"key": "namespace.statcan.gc.ca/purpose",
 					"operator": "Equal",
 					"value": "system",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "node.statcan.gc.ca/use",
+					"operator": "Equal",
+					"value": "general",
+				},
+			],
+		},
+	}}}
+
+	# Evaluate the violation with the input
+	results := violation with input as input with data.inventory.cluster as cluster
+
+	# Do not expect a violation
+	count(results) == 0
+}
+
+
+test_unclassified_pod_with_protected_b_node_toleration_is_violation {
+	cluster := {
+		"namespace": {
+			"system": {
+				"metadata": {
+					"labels": {
+						"namespace.statcan.gc.ca/purpose": ""
+					}
+				}
+			}
+		}
+	}
+
+	input := {"review": {"object": {
+		"kind": "Pod",
+		"metadata": {
+			"name": "user-pod",
+			"namespace": "user",
+			"labels": {"app": "user-pod"},
+		},
+		"spec": {
+			"containers": [{
+				"name": "user-pod",
+				"image": "nginx:latest",
+				"resources": {
+					"limits": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+					"requests": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+				},
+			}],
+			"tolerations": [
+				{
+					"effect": "NoSchedule",
+					"key": "data.statcan.gc.ca/classification",
+					"operator": "Equal",
+					"value": "protected-b",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "node.statcan.gc.ca/use",
+					"operator": "Equal",
+					"value": "general",
+				},
+			],
+		},
+	}}}
+
+	# Evaluate the violation with the input
+	results := violation with input as input with data.inventory.cluster as cluster
+
+	# Expect a violation
+	count(results) > 0
+}
+
+
+test_protected_b_pod_with_protected_b_node_toleration_is_not_violation {
+	cluster := {
+		"namespace": {
+			"system": {
+				"metadata": {
+					"labels": {
+						"namespace.statcan.gc.ca/purpose": ""
+					}
+				}
+			}
+		}
+	}
+
+	input := {"review": {"object": {
+		"kind": "Pod",
+		"metadata": {
+			"name": "user-pod",
+			"namespace": "user",
+			"labels": {"app": "user-pod", "data.statcan.gc.ca/classification": "protected-b"},
+		},
+		"spec": {
+			"containers": [{
+				"name": "user-pod",
+				"image": "nginx:latest",
+				"resources": {
+					"limits": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+					"requests": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+				},
+			}],
+			"tolerations": [
+				{
+					"effect": "NoSchedule",
+					"key": "data.statcan.gc.ca/classification",
+					"operator": "Equal",
+					"value": "protected-b",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "node.statcan.gc.ca/use",
+					"operator": "Equal",
+					"value": "general",
+				},
+			],
+		},
+	}}}
+
+	# Evaluate the violation with the input
+	results := violation with input as input with data.inventory.cluster as cluster
+
+	# Do not expect a violation
+	count(results) == 0
+}
+
+
+test_protected_b_pod_with_unclassified_node_toleration_is_violation {
+	cluster := {
+		"namespace": {
+			"system": {
+				"metadata": {
+					"labels": {
+						"namespace.statcan.gc.ca/purpose": ""
+					}
+				}
+			}
+		}
+	}
+
+	input := {"review": {"object": {
+		"kind": "Pod",
+		"metadata": {
+			"name": "user-pod",
+			"namespace": "user",
+			"labels": {"app": "user-pod", "data.statcan.gc.ca/classification": "protected-b"},
+		},
+		"spec": {
+			"containers": [{
+				"name": "user-pod",
+				"image": "nginx:latest",
+				"resources": {
+					"limits": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+					"requests": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+				},
+			}],
+			"tolerations": [
+				{
+					"effect": "NoSchedule",
+					"key": "data.statcan.gc.ca/classification",
+					"operator": "Equal",
+					"value": "unclassified",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "node.statcan.gc.ca/use",
+					"operator": "Equal",
+					"value": "general",
+				},
+			],
+		},
+	}}}
+
+	# Evaluate the violation with the input
+	results := violation with input as input with data.inventory.cluster as cluster
+
+	# Expect a violation
+	count(results) > 0
+}
+
+
+test_unclassified_pod_with_unclassified_node_toleration_is_not_violation {
+	cluster := {
+		"namespace": {
+			"system": {
+				"metadata": {
+					"labels": {
+						"namespace.statcan.gc.ca/purpose": ""
+					}
+				}
+			}
+		}
+	}
+
+	input := {"review": {"object": {
+		"kind": "Pod",
+		"metadata": {
+			"name": "user-pod",
+			"namespace": "user",
+			"labels": {"app": "user-pod"},
+		},
+		"spec": {
+			"containers": [{
+				"name": "user-pod",
+				"image": "nginx:latest",
+				"resources": {
+					"limits": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+					"requests": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+				},
+			}],
+			"tolerations": [
+				{
+					"effect": "NoSchedule",
+					"key": "data.statcan.gc.ca/classification",
+					"operator": "Equal",
+					"value": "unclassified",
 				},
 				{
 					"effect": "NoSchedule",

--- a/pod-security-policy/deny-user-specified-tolerations/src_test.rego
+++ b/pod-security-policy/deny-user-specified-tolerations/src_test.rego
@@ -1,0 +1,57 @@
+package deny_user_pod_system_node
+
+# If a user pod is submitted from a non-system namespace and contains a
+# toleration allowing it to be scheduled to a system node, then the
+# request should be denied.
+test_user_pod_with_system_node_toleration_is_violation {
+	input := {"review": {"object": {
+		"kind": "Pod",
+		"metadata": {
+			"name": "user-pod",
+			"namespace": "default",
+			"labels": {"app": "user-pod"},
+		},
+		"spec": {
+			"containers": [{
+				"name": "user-pod",
+				"image": "nginx:latest",
+				"resources": {
+					"limits": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+					"requests": {
+						"cpu": "50m",
+						"memory": "50Mi",
+					},
+				},
+			}],
+			"tolerations": [
+				{
+					"effect": "NoSchedule",
+					"key": "classification",
+					"operator": "Equal",
+					"value": "sensitive",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "purpose",
+					"operator": "Equal",
+					"value": "system",
+				},
+				{
+					"effect": "NoSchedule",
+					"key": "use",
+					"operator": "Equal",
+					"value": "general",
+				},
+			],
+		},
+	}}}
+
+	# Evaluate the violation with the input
+	results := violation with input as input
+
+	# Expect a violation
+	count(results) > 0
+}

--- a/pod-security-policy/deny-user-specified-tolerations/template.yaml
+++ b/pod-security-policy/deny-user-specified-tolerations/template.yaml
@@ -1,0 +1,88 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  creationTimestamp: null
+  name: .
+spec:
+  crd:
+    spec:
+      names:
+        kind: .
+  targets:
+  - rego: |-
+      package deny_user_pod_system_node
+
+      system_namespace_label = "namespace.statcan.gc.ca/purpose"
+      system_namespace = ["system", "daaas"]
+
+      classification_label = "data.statcan.gc.ca/classification"
+
+      is_system_namespace(pod) {
+        # Get the namespace object that the pod belongs to
+        namespace := data.inventory.cluster["namespace"][pod.metadata.namespace]
+        # Note: can also access namespaced resources this way, e.g.
+        # data.inventory.namespace["your namespace"].rolebindings["myrolebinding"]...
+
+        # If the namespace has purpose "system", then this policy does not apply.
+        ns := namespace.metadata.labels[system_namespace_label]
+        count([system | system := system_namespace[_]; system == ns]) > 0
+      }
+
+
+      violation[{"msg": msg, "details": {}}] {
+        resource := input.review.object
+
+        # Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+        purpose_toleration := resource.spec.tolerations[_]
+        purpose_toleration["key"] == system_namespace_label
+        purpose_toleration["value"] == "system"
+
+        not is_system_namespace(resource)
+
+        # Get pod name and namespace
+        pod_name := resource.metadata.name
+        namespace := resource.metadata.namespace
+        msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to a system node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
+      }
+
+      violation[{"msg": msg, "details": {}}] {
+        resource := input.review.object
+
+        # Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+        purpose_toleration := resource.spec.tolerations[_]
+        purpose_toleration["key"] == classification_label
+        purpose_toleration["value"] == "protected-b"
+
+        # Check if classification label is absent or unclassified, this pod must not go to a protected-b node pool
+        not resource.metadata.labels[classification_label] == "protected-b"
+
+        not is_system_namespace(resource)
+
+
+        # Get pod name and namespace
+        pod_name := resource.metadata.name
+        namespace := resource.metadata.namespace
+        msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to a protected-b node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
+      }
+
+      violation[{"msg": msg, "details": {}}] {
+        resource := input.review.object
+
+        # Check if any toleration has the purpose key - if this key doesn't exist, the user doesn't have this toleration.
+        purpose_toleration := resource.spec.tolerations[_]
+        purpose_toleration["key"] == classification_label
+        purpose_toleration["value"] == "unclassified"
+
+        # Check if classification label is absent or unclassified, this pod must not go to a protected-b node pool
+        resource.metadata.labels[classification_label] == "protected-b"
+
+        not is_system_namespace(resource)
+
+
+        # Get pod name and namespace
+        pod_name := resource.metadata.name
+        namespace := resource.metadata.namespace
+        msg := sprintf("Forbidden: Pod %s in namespace %s has toleration %s:%s, which would allow it to be scheduled to an unclassified node. Please ensure that your pod spec does not contain the specified toleration.", [pod_name, namespace, purpose_toleration["key"], purpose_toleration["value"]])
+      }
+    target: admission.k8s.gatekeeper.sh
+status: {}

--- a/pod-security-policy/deny-user-specified-tolerations/template.yaml
+++ b/pod-security-policy/deny-user-specified-tolerations/template.yaml
@@ -2,12 +2,12 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   creationTimestamp: null
-  name: .
+  name: denyuserspecifiedtolerations
 spec:
   crd:
     spec:
       names:
-        kind: .
+        kind: DenyUserSpecifiedTolerations
   targets:
   - rego: |-
       package deny_user_pod_system_node


### PR DESCRIPTION
Add policy to prevent users from manually adding tolerations to their pod spec. If such tolerations are added to a user pod, the gatekeeper policy will deny the request.