### PR TITLE
feat(restrict-hostnames): add the errorMsgAdditionalDetails parameter

### DIFF
--- a/general/restrict-hostnames/examples/constraint.yaml
+++ b/general/restrict-hostnames/examples/constraint.yaml
@@ -10,6 +10,8 @@ spec:
       - apiGroups: ["networking.istio.io"]
         kinds: ["VirtualService"]
   parameters:
+    # Hostnames that should be exempt from the policy. Glob patterns can be specified.
     exemptions:
       - '*.example.ca'
+    # Extra information that should be appended to the error message.
     errorMsgAdditionalDetails: ""

--- a/general/restrict-hostnames/examples/constraint.yaml
+++ b/general/restrict-hostnames/examples/constraint.yaml
@@ -12,3 +12,4 @@ spec:
   parameters:
     exemptions:
       - '*.example.ca'
+    errorMsgAdditionalDetails: ""

--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -79,7 +79,7 @@ violation[{"msg": msg}] {
 
 	count(invalid_hostpaths) > 0
 
-	msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v. %v", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
+	msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
 }
 
 # Virtual Service
@@ -99,7 +99,7 @@ violation[{"msg": msg}] {
 
 	count(invalid_hostpaths) > 0
 
-	msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %v", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
+	msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
 }
 
 # Hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
@@ -132,5 +132,5 @@ violation[{"msg": msg}] {
 	conflicts := ingress_conflicts | vs_conflicts
 
 	count(conflicts) > 0
-	msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %v", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
+	msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
 }

--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -79,7 +79,7 @@ violation[{"msg": msg}] {
 
 	count(invalid_hostpaths) > 0
 
-	msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v", [invalid_hostpaths])
+	msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v. %v", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
 }
 
 # Virtual Service
@@ -99,7 +99,7 @@ violation[{"msg": msg}] {
 
 	count(invalid_hostpaths) > 0
 
-	msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v", [invalid_hostpaths])
+	msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %v", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
 }
 
 # Hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
@@ -132,5 +132,5 @@ violation[{"msg": msg}] {
 	conflicts := ingress_conflicts | vs_conflicts
 
 	count(conflicts) > 0
-	msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v", [kind, host, conflicts])
+	msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %v", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
 }

--- a/general/restrict-hostnames/template.yaml
+++ b/general/restrict-hostnames/template.yaml
@@ -104,7 +104,7 @@ spec:
 
           count(invalid_hostpaths) > 0
 
-          msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v. %v", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
+          msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
         }
 
         # Virtual Service
@@ -124,7 +124,7 @@ spec:
 
           count(invalid_hostpaths) > 0
 
-          msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %v", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
+          msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
         }
 
         # Hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
@@ -157,5 +157,5 @@ spec:
           conflicts := ingress_conflicts | vs_conflicts
 
           count(conflicts) > 0
-          msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %v", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
+          msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
         }

--- a/general/restrict-hostnames/template.yaml
+++ b/general/restrict-hostnames/template.yaml
@@ -17,6 +17,9 @@ spec:
               type: array
               items:
                 type: string
+            errorMsgAdditionalDetails:
+              type: string
+              default: ""
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |-
@@ -101,7 +104,7 @@ spec:
 
           count(invalid_hostpaths) > 0
 
-          msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v", [invalid_hostpaths])
+          msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v. %v", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
         }
 
         # Virtual Service
@@ -121,7 +124,7 @@ spec:
 
           count(invalid_hostpaths) > 0
 
-          msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v", [invalid_hostpaths])
+          msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %v", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
         }
 
         # Hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
@@ -154,5 +157,5 @@ spec:
           conflicts := ingress_conflicts | vs_conflicts
 
           count(conflicts) > 0
-          msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v", [kind, host, conflicts])
+          msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %v", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
         }


### PR DESCRIPTION
The errorMsgAdditionalDetails parameter can be used to provide a link to the policy's runbook/documentation. 