### PR TITLE
fix(restrict-hostnames): account for ingress or virtualservice with no path

### DIFF
--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -72,7 +72,8 @@ violation[{"msg": msg}] {
 	invalid_hostpaths := {hostpath |
 		rule := input.review.object.spec.rules[_]
 		host := rule.host
-		path := rule.http.paths[_].path
+		paths := ({path | path := rule.http.paths[_].path} | {path | path := ""})
+		path := paths[_]
 
 		hostpath := is_invalid(host, path)
 	}

--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -73,28 +73,9 @@ violation[{"msg": msg}] {
 	invalid_hostpaths := {hostpath |
 		rule := input.review.object.spec.rules[_]
 		host := rule.host
-		path := rule.http.paths[_].path
+		path := object.get(rule.http.paths[_], "path", "")
 
 		hostpath := is_invalid(host, path)
-	}
-
-	count(invalid_hostpaths) > 0
-
-	msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
-}
-
-# Pathless Ingress
-violation[{"msg": msg}] {
-	input.review.kind.kind == "Ingress"
-	input.review.kind.group == "networking.k8s.io"
-
-	# Gather all invalid host and path combinations
-	invalid_hostpaths := {hostpath |
-		rule := input.review.object.spec.rules[_]
-		host := rule.host
-		count({path | path := rule.http.paths[_].path}) = 0
-
-		hostpath := is_invalid(host, "")
 	}
 
 	count(invalid_hostpaths) > 0

--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -72,7 +72,7 @@ violation[{"msg": msg}] {
 	invalid_hostpaths := {hostpath |
 		rule := input.review.object.spec.rules[_]
 		host := rule.host
-		path := object.get(rule.http.paths[_], "path", "")
+		path := object.get(rule.http.paths[_], "path", "/")
 
 		hostpath := is_invalid(host, path)
 	}
@@ -109,11 +109,11 @@ violation[{"msg": msg}] {
 
 	# Gather all invalid host and path combinations
 	invalid_hostpaths := {hostpath |
-		count(({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) = 0
+		count(({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) == 0
 
 		host := input.review.object.spec.hosts[_]
 
-		hostpath := is_invalid(host, "")
+		hostpath := is_invalid(host, "/")
 	}
 
 	count(invalid_hostpaths) > 0
@@ -163,9 +163,9 @@ violation[{"msg": msg}] {
 	hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
 	host := hosts[_]
 	paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
-	count(paths) = 0
+	count(paths) == 0
 
-	not is_allowed(host, "")
+	not is_allowed(host, "/")
 
 	ingress_conflicts := {output |
 		conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]

--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -54,7 +54,6 @@ is_allowed(host, path) {
 
 # Determines if a host and path combination is invalid and returns a concatenated response.
 is_invalid(host, path) = invalid {
-
 	# Check if the hostname is exempt
 	not is_exempt(host)
 
@@ -185,5 +184,5 @@ violation[{"msg": msg}] {
 	conflicts := ingress_conflicts | vs_conflicts
 
 	count(conflicts) > 0
-	msg := sprintf("Pathless %v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
+	msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
 }

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -1248,7 +1248,7 @@ test_allowed_vs_hostname_conflicts {
 	result == set()
 }
 
-# Test for ingress with unallowed host and no path
+# Test for Ingress with unallowed host and no path
 test_ingress_unallowed_host_no_path {
 	ingress := {
 		"apiVersion": "admission.k8s.io/v1beta1",
@@ -1265,7 +1265,7 @@ test_ingress_unallowed_host_no_path {
 			},
 			"object": {
 				"metadata": {
-					"name": "unallowedtest",
+					"name": "unallowed-ingress",
 					"namespace": "test",
 				},
 				"spec": {"rules": [{
@@ -1283,6 +1283,43 @@ test_ingress_unallowed_host_no_path {
 	}
 
 	result := violation with input as ingress with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
+
+	# Violation expected
+	print(result)
+	count(result) > 0
+}
+
+# Test for VirtualService with unallowed host and no path
+test_vs_unallowed_host_no_path {
+	vs := {
+		"apiVersion": "admission.k8s.io/v1beta1",
+		"kind": "AdmissionReview",
+		"review": {
+			"kind": {
+				"group": "networking.istio.io",
+				"kind": "VirtualService",
+			},
+			"operation": "CREATE",
+			"userInfo": {
+				"groups": null,
+				"username": "alice",
+			},
+			"object": {
+				"metadata": {
+					"name": "unallowed-vs",
+					"namespace": "test",
+				},
+				"spec": {
+					"hosts": ["nope.com", "nah.com", "ok.test.com"],
+					"http": [{"route": [{"destination": {"host": "myservice"}}]}],
+				},
+			},
+		},
+	}
+
+	exemptions := ["*.test.com"]
+
+	result := violation with input as vs with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Violation expected
 	print(result)

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -1376,7 +1376,7 @@ test_vs_unallowed_host_no_path {
 }
 
 # Test for an allowed VS which sets a host but not matches on the path.
-# This is effectively the same as `test.com` is effectively the same as `test.com/` since the `/` is a seperator in our prefix strategy.
+# `test.com` is effectively the same as `test.com/` since the `/` is a seperator in our prefix strategy.
 test_vs_allowed_no_path {
 	vs_review := {
 		"apiVersion": "admission.k8s.io/v1beta1",
@@ -1416,6 +1416,58 @@ test_vs_allowed_no_path {
 	exemptions := [""]
 
 	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
+
+	# Empty set means no violations
+	result == set()
+}
+
+# Test for an allowed Ingress which sets a host but not matches on the path.
+# `test.com` is effectively the same as `test.com/` since the `/` is a seperator in our prefix strategy.
+test_ingress_allowed_no_path {
+	ingress_review := {
+		"apiVersion": "admission.k8s.io/v1beta1",
+		"kind": "AdmissionReview",
+		"review": {
+			"kind": {
+				"group": "networking.k8s.io",
+				"kind": "Ingress",
+			},
+			"operation": "CREATE",
+			"userInfo": {
+				"groups": null,
+				"username": "alice",
+			},
+			"object": {
+				"metadata": {
+					"name": "test",
+					"namespace": "test",
+				},
+				"spec": {"rules": [{
+					"host": "test.com",
+					"http": {"paths": [{
+						"pathType": "ImplementationSpecific",
+						"backend": {"service": {
+							"name": "test",
+							"port": {"number": 443},
+						}},
+					}]},
+				}]},
+			},
+		},
+	}
+
+	namespaces := {"test": {
+		"apiVersion": "v1",
+		"kind": "Namespace",
+		"metadata": {
+			"annotations": {"ingress.statcan.gc.ca/allowed-hosts": `[{"host": "test.com","path":"/"}]`},
+			"name": "test",
+		},
+	}}
+
+	exemptions := [""]
+
+	result := violation with input as ingress_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Empty set means no violations
 	result == set()

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -222,15 +222,13 @@ test_ingress_allowed_path {
 				},
 				"spec": {"rules": [{
 					"host": "test.com",
-					"http": {"paths": [
-						{
-							"path": "/finance",
-							"backend": {
-								"serviceName": "banking",
-								"servicePort": 443,
-							},
+					"http": {"paths": [{
+						"path": "/finance",
+						"backend": {
+							"serviceName": "banking",
+							"servicePort": 443,
 						},
-					]},
+					}]},
 				}]},
 			},
 		},

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -252,7 +252,7 @@ test_ingress_unallowed_path {
 		},
 	}}
 
-	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces
+	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# 1 message for /other which is not allowed.
 	print(result)
@@ -311,7 +311,7 @@ test_ingress_no_annotation {
 		},
 	}}
 
-	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces
+	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# result with entry means there was a violation
 	print(result)
@@ -466,7 +466,7 @@ test_vs_wrong_host {
 
 	exemptions := [""]
 
-	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions
+	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	count(result) > 0
 	print(result)
@@ -513,7 +513,7 @@ test_vs_multi_host_fail {
 
 	exemptions := [""]
 
-	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions
+	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	#Empty set means no violations
 	print(result)
@@ -608,7 +608,7 @@ test_vs_no_annotation {
 
 	exemptions := [""]
 
-	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions
+	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	count(result) > 0
 	print(result)
@@ -834,7 +834,7 @@ test_ingress_hostname_conflicts {
 
 	exemptions := ["*.test.com"]
 
-	result := violation with input as new_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress as existing_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress2 as existing_ingress2 with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs as existing_vs with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs2 as existing_vs2 with input.parameters.exemptions as exemptions
+	result := violation with input as new_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress as existing_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress2 as existing_ingress2 with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs as existing_vs with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs2 as existing_vs2 with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Duplicate hostname violation expected
 	print(result)
@@ -1104,7 +1104,7 @@ test_vs_hostname_conflicts {
 
 	exemptions := ["*.test.com"]
 
-	result := violation with input as new_vs with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress as existing_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress2 as existing_ingress2 with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs as existing_vs with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs2 as existing_vs2 with input.parameters.exemptions as exemptions
+	result := violation with input as new_vs with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress as existing_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress2 as existing_ingress2 with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs as existing_vs with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs2 as existing_vs2 with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Duplicate hostname violation expected
 	print(result)

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -1270,19 +1270,13 @@ test_ingress_unallowed_host_no_path {
 				},
 				"spec": {"rules": [{
 					"host": "unallowedtest.com",
-					"http": {"paths": [
-						{
-							"pathType": "ImplementationSpecific",
-							"backend": {
-								"service": {
-									"name": "unallowedtest",
-									"port": {
-										"number": 443
-									}
-								}
-							},
-						},
-					]},
+					"http": {"paths": [{
+						"pathType": "ImplementationSpecific",
+						"backend": {"service": {
+							"name": "unallowedtest",
+							"port": {"number": 443},
+						}},
+					}]},
 				}]},
 			},
 		},

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -78,7 +78,7 @@ test_ingress_allow_all {
 		},
 	}}
 
-	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces
+	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# If result set is empty, no violations
 	result == set()
@@ -136,7 +136,7 @@ test_ingress_case_mismatch {
 		},
 	}}
 
-	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces
+	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# If result set is empty, no violations
 	result == set()
@@ -194,7 +194,7 @@ test_ingress_empty_path {
 		},
 	}}
 
-	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces
+	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# If result set is empty, no violations
 	result == set()
@@ -372,7 +372,7 @@ test_ingress_exempt {
 
 	exemptions := ["*.test.com"]
 
-	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions
+	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Empty set means no violations
 	result == set()
@@ -419,7 +419,7 @@ test_vs_allowed {
 
 	exemptions := [""]
 
-	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions
+	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Empty set means no violations
 	result == set()
@@ -561,7 +561,7 @@ test_vs_multi_host {
 
 	exemptions := [""]
 
-	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions
+	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Empty set means no violations
 	result == set()
@@ -655,7 +655,7 @@ test_vs_exempt_namespace_hosts {
 
 	exemptions := [""]
 
-	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions
+	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Empty set means no violations
 	result == set()
@@ -702,7 +702,7 @@ test_vs_regex {
 
 	exemptions := [""]
 
-	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions
+	result := violation with input as vs_review with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Empty set means no violations
 	result == set()
@@ -976,7 +976,7 @@ test_allowed_ingress_hostname_conflicts {
 		},
 	}}
 
-	result := violation with input as new_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress as existing_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress2 as existing_ingress2 with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs as existing_vs with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs2 as existing_vs2 with input.parameters.exemptions as exemptions with data.inventory.cluster.v1.Namespace as namespaces
+	result := violation with input as new_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress as existing_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress2 as existing_ingress2 with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs as existing_vs with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs2 as existing_vs2 with input.parameters.exemptions as exemptions with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Empty set means no violations
 	result == set()
@@ -1242,7 +1242,7 @@ test_allowed_vs_hostname_conflicts {
 
 	exemptions := ["*.test.com"]
 
-	result := violation with input as new_vs with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress as existing_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress2 as existing_ingress2 with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs as existing_vs with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs2 as existing_vs2 with input.parameters.exemptions as exemptions with data.inventory.cluster.v1.Namespace as namespaces
+	result := violation with input as new_vs with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress as existing_ingress with data.inventory.namespace.red["networking.k8s.io/v1"].Ingress.red_ingress2 as existing_ingress2 with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs as existing_vs with data.inventory.namespace.red["networking.istio.io/v1beta1"].VirtualService.red_vs2 as existing_vs2 with input.parameters.exemptions as exemptions with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 
 	# Empty set means no violations
 	result == set()

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -872,11 +872,11 @@ test_ingress_hostname_conflicts {
 				"spec": {"rules": [{
 					"host": "red.test.com",
 					"http": {"paths": [{
-						"path": "/finance",
-						"backend": {
-							"serviceName": "banking",
-							"servicePort": 443,
-						},
+						"pathType": "ImplementationSpecific",
+						"backend": {"service": {
+							"name": "red-from-blue",
+							"port": {"number": 443},
+						}},
 					}]},
 				}]},
 			},

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -78,7 +78,7 @@ test_ingress_allow_all {
 		},
 	}}
 
-	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
+	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces
 
 	# If result set is empty, no violations
 	result == set()
@@ -136,7 +136,7 @@ test_ingress_case_mismatch {
 		},
 	}}
 
-	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
+	result := violation with input as ingress with data.inventory.cluster.v1.Namespace as namespaces
 
 	# If result set is empty, no violations
 	result == set()

--- a/general/restrict-hostnames/template.yaml
+++ b/general/restrict-hostnames/template.yaml
@@ -97,8 +97,7 @@ spec:
           invalid_hostpaths := {hostpath |
             rule := input.review.object.spec.rules[_]
             host := rule.host
-            paths := ({path | path := rule.http.paths[_].path} | {path | path := ""})
-            path := paths[_]
+            path := object.get(rule.http.paths[_], "path", "")
 
             hostpath := is_invalid(host, path)
           }
@@ -128,6 +127,25 @@ spec:
           msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
         }
 
+        # Pathless Virtual Service
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "VirtualService"
+          input.review.kind.group == "networking.istio.io"
+
+          # Gather all invalid host and path combinations
+          invalid_hostpaths := {hostpath |
+            count(({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) = 0
+
+            host := input.review.object.spec.hosts[_]
+
+            hostpath := is_invalid(host, "")
+          }
+
+          count(invalid_hostpaths) > 0
+
+          msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
+        }
+
         # Hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
         violation[{"msg": msg}] {
           kind := input.review.kind.kind
@@ -140,6 +158,39 @@ spec:
           path := paths[_]
 
           not is_allowed(host, path)
+
+          ingress_conflicts := {output |
+            conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]
+            conflict.spec.rules[_].host == host
+            conflict.metadata.namespace != input.review.object.metadata.namespace
+            output := concat("/", ["Ingress", other_namespace, other_name])
+          }
+
+          vs_conflicts := {output |
+            conflict := data.inventory.namespace[other_namespace]["networking.istio.io/v1beta1"].VirtualService[other_name]
+            conflict.spec.hosts[_] == host
+            conflict.metadata.namespace != input.review.object.metadata.namespace
+            output := concat("/", ["VirtualService", other_namespace, other_name])
+          }
+
+          conflicts := ingress_conflicts | vs_conflicts
+
+          count(conflicts) > 0
+          msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
+        }
+
+        # Pathless hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
+        violation[{"msg": msg}] {
+          kind := input.review.kind.kind
+          re_match("^(Ingress|VirtualService)$", kind)
+          re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
+
+          hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
+          host := hosts[_]
+          paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
+          count(paths) = 0
+
+          not is_allowed(host, "")
 
           ingress_conflicts := {output |
             conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]

--- a/general/restrict-hostnames/template.yaml
+++ b/general/restrict-hostnames/template.yaml
@@ -97,7 +97,8 @@ spec:
           invalid_hostpaths := {hostpath |
             rule := input.review.object.spec.rules[_]
             host := rule.host
-            path := rule.http.paths[_].path
+            paths := ({path | path := rule.http.paths[_].path} | {path | path := ""})
+            path := paths[_]
 
             hostpath := is_invalid(host, path)
           }

--- a/general/restrict-hostnames/template.yaml
+++ b/general/restrict-hostnames/template.yaml
@@ -97,7 +97,7 @@ spec:
           invalid_hostpaths := {hostpath |
             rule := input.review.object.spec.rules[_]
             host := rule.host
-            path := object.get(rule.http.paths[_], "path", "")
+            path := object.get(rule.http.paths[_], "path", "/")
 
             hostpath := is_invalid(host, path)
           }
@@ -134,11 +134,11 @@ spec:
 
           # Gather all invalid host and path combinations
           invalid_hostpaths := {hostpath |
-            count(({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) = 0
+            count(({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) == 0
 
             host := input.review.object.spec.hosts[_]
 
-            hostpath := is_invalid(host, "")
+            hostpath := is_invalid(host, "/")
           }
 
           count(invalid_hostpaths) > 0
@@ -188,9 +188,9 @@ spec:
           hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
           host := hosts[_]
           paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
-          count(paths) = 0
+          count(paths) == 0
 
-          not is_allowed(host, "")
+          not is_allowed(host, "/")
 
           ingress_conflicts := {output |
             conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]


### PR DESCRIPTION
Addressing CN-1121.

Done:
- Fix existing test cases by adding a placeholder for `input.parameters.errorMsgAdditionalDetails`
- Add a test case for the example pathless ingress that escapes the policies
- Adjust path check so that the ingress no longer escapes
- Add a test case for a pathless virtualservice that escapes the policies

But:
- The path check fix that worked for the ingress makes other virtualservice test cases fail
  - It appears to consider the ingress and virtualservice as having an empty path *in addition* to any existing paths.
  - I confirmed this by adding an also now failing test case for an ingress that is limited to, and using, an allowed path

Done After:
- Confirm that the issue also impacts the hostname conflict violation (adjusted one of its test cases to have no path)
- Adjust the path checks so that all tests succeed. 
  - This was done with an `object.get` for the Ingress violation.
  - For the VirtualService and Hostpath Conflict violation, the only working way I've found thus far is to create a near-duplicate violation that checks that there are no paths and in that case validates against "" instead of passing the path variable.
- Copy finalized rego over to the template  