### PR TITLE
refactor(restrict-hostnames): condensed violations

### DIFF
--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -54,7 +54,6 @@ is_allowed(host, path) {
 
 # Determines if a host and path combination is invalid and returns a concatenated response.
 is_invalid(host, path) = invalid {
-
 	# Check if the hostname is exempt
 	not is_exempt(host)
 

--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -109,8 +109,7 @@ violation[{"msg": msg}] {
 	re_match("^(Ingress|VirtualService)$", kind)
 	re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
 
-	hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
-	host := hosts[_]
+	host := get_hosts()[_]
 	path := get_paths()[_]
 
 	not is_allowed(host, path)

--- a/general/restrict-hostnames/rego/src.rego
+++ b/general/restrict-hostnames/rego/src.rego
@@ -84,12 +84,12 @@ violation[{"msg": msg}] {
 }
 
 get_paths = paths {
-	count(({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) > 0
-	paths := ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
+	count(({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) > 0
+	paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
 }
 
 get_paths = paths {
-	count(({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) == 0
+	count(({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) == 0
 	paths := ["/"]
 }
 
@@ -119,43 +119,9 @@ violation[{"msg": msg}] {
 
 	hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
 	host := hosts[_]
-	paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
-	path := paths[_]
+	path := get_paths()[_]
 
 	not is_allowed(host, path)
-
-	ingress_conflicts := {output |
-		conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]
-		conflict.spec.rules[_].host == host
-		conflict.metadata.namespace != input.review.object.metadata.namespace
-		output := concat("/", ["Ingress", other_namespace, other_name])
-	}
-
-	vs_conflicts := {output |
-		conflict := data.inventory.namespace[other_namespace]["networking.istio.io/v1beta1"].VirtualService[other_name]
-		conflict.spec.hosts[_] == host
-		conflict.metadata.namespace != input.review.object.metadata.namespace
-		output := concat("/", ["VirtualService", other_namespace, other_name])
-	}
-
-	conflicts := ingress_conflicts | vs_conflicts
-
-	count(conflicts) > 0
-	msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
-}
-
-# Pathless hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
-violation[{"msg": msg}] {
-	kind := input.review.kind.kind
-	re_match("^(Ingress|VirtualService)$", kind)
-	re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
-
-	hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
-	host := hosts[_]
-	paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
-	count(paths) == 0
-
-	not is_allowed(host, "/")
 
 	ingress_conflicts := {output |
 		conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]

--- a/general/restrict-hostnames/rego/src_test.rego
+++ b/general/restrict-hostnames/rego/src_test.rego
@@ -1657,7 +1657,7 @@ test_vs_not_allowed_no_host_not_allowed {
 		},
 	}}
 
-	exemptions := [""]
+	exemptions := []
 
 	result := violation with input as vs with data.inventory.cluster.v1.Namespace as namespaces with input.parameters.exemptions as exemptions with input.parameters.errorMsgAdditionalDetails as "(Additional details placeholder)"
 

--- a/general/restrict-hostnames/template.yaml
+++ b/general/restrict-hostnames/template.yaml
@@ -79,6 +79,7 @@ spec:
 
         # Determines if a host and path combination is invalid and returns a concatenated response.
         is_invalid(host, path) = invalid {
+
           # Check if the hostname is exempt
           not is_exempt(host)
 
@@ -88,62 +89,43 @@ spec:
           invalid := concat("", [host, path])
         }
 
-        # Ingress
+        get_paths = paths {
+          count(({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) > 0
+          paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
+        }
+
+        get_paths = paths {
+          count(({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) == 0
+          paths := ["/"]
+        }
+
+        get_hosts = hosts {
+          count({host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}) > 0
+          hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
+        }
+
+        get_hosts = hosts {
+          count({host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}) == 0
+          hosts := [""]
+        }
+
+        # Ingress or VirtualService must have valid hostpaths
         violation[{"msg": msg}] {
-          input.review.kind.kind == "Ingress"
-          input.review.kind.group == "networking.k8s.io"
+          kind := input.review.kind.kind
+          re_match("^(Ingress|VirtualService)$", kind)
+          re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
 
           # Gather all invalid host and path combinations
           invalid_hostpaths := {hostpath |
-            rule := input.review.object.spec.rules[_]
-            host := rule.host
-            path := object.get(rule.http.paths[_], "path", "/")
+            host := get_hosts()[_]
+            path := get_paths()[_]
 
             hostpath := is_invalid(host, path)
           }
 
           count(invalid_hostpaths) > 0
 
-          msg := sprintf("hostpaths in the ingress are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
-        }
-
-        # Virtual Service
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "VirtualService"
-          input.review.kind.group == "networking.istio.io"
-
-          # Gather all invalid host and path combinations
-          invalid_hostpaths := {hostpath |
-            paths := ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
-
-            path := paths[_]
-            host := input.review.object.spec.hosts[_]
-
-            hostpath := is_invalid(host, path)
-          }
-
-          count(invalid_hostpaths) > 0
-
-          msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
-        }
-
-        # Pathless Virtual Service
-        violation[{"msg": msg}] {
-          input.review.kind.kind == "VirtualService"
-          input.review.kind.group == "networking.istio.io"
-
-          # Gather all invalid host and path combinations
-          invalid_hostpaths := {hostpath |
-            count(({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix}) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) == 0
-
-            host := input.review.object.spec.hosts[_]
-
-            hostpath := is_invalid(host, "/")
-          }
-
-          count(invalid_hostpaths) > 0
-
-          msg := sprintf("hostpaths in the virtualservice are not valid for this namespace: %v. %s", [invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
+          msg := sprintf("hostpaths in the %v are not valid for this namespace: %v. %s", [kind, invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
         }
 
         # Hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
@@ -152,45 +134,10 @@ spec:
           re_match("^(Ingress|VirtualService)$", kind)
           re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
 
-          hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
-          host := hosts[_]
-          paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
-          path := paths[_]
+          host := get_hosts()[_]
+          path := get_paths()[_]
 
           not is_allowed(host, path)
-
-          ingress_conflicts := {output |
-            conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]
-            conflict.spec.rules[_].host == host
-            conflict.metadata.namespace != input.review.object.metadata.namespace
-            output := concat("/", ["Ingress", other_namespace, other_name])
-          }
-
-          vs_conflicts := {output |
-            conflict := data.inventory.namespace[other_namespace]["networking.istio.io/v1beta1"].VirtualService[other_name]
-            conflict.spec.hosts[_] == host
-            conflict.metadata.namespace != input.review.object.metadata.namespace
-            output := concat("/", ["VirtualService", other_namespace, other_name])
-          }
-
-          conflicts := ingress_conflicts | vs_conflicts
-
-          count(conflicts) > 0
-          msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
-        }
-
-        # Pathless hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
-        violation[{"msg": msg}] {
-          kind := input.review.kind.kind
-          re_match("^(Ingress|VirtualService)$", kind)
-          re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
-
-          hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
-          host := hosts[_]
-          paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
-          count(paths) == 0
-
-          not is_allowed(host, "/")
 
           ingress_conflicts := {output |
             conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]

--- a/general/restrict-hostnames/template.yaml
+++ b/general/restrict-hostnames/template.yaml
@@ -37,124 +37,123 @@ spec:
 
         # Allowed hosts scraped from the above annotation.
         allowedHosts := hosts {
-          json.is_valid(data.inventory.cluster.v1.Namespace[input.review.object.metadata.namespace].metadata.annotations[annotation])
-          hosts := normalize_hosts(json.unmarshal(data.inventory.cluster.v1.Namespace[input.review.object.metadata.namespace].metadata.annotations[annotation]))
+        	json.is_valid(data.inventory.cluster.v1.Namespace[input.review.object.metadata.namespace].metadata.annotations[annotation])
+        	hosts := normalize_hosts(json.unmarshal(data.inventory.cluster.v1.Namespace[input.review.object.metadata.namespace].metadata.annotations[annotation]))
         }
 
         # Normalizes the objects for easier logic by lowercasing the path.
         normalize_hosts(hosts) = normalized_hosts {
-          normalized_hosts := [host |
-            current_host_object := hosts[_]
-            host := {"host": current_host_object.host, "path": lower(current_host_object.path)}
-          ]
+        	normalized_hosts := [host |
+        		current_host_object := hosts[_]
+        		host := {"host": current_host_object.host, "path": lower(current_host_object.path)}
+        	]
         }
 
         # Exemptions for hosts passed in via the configuration of the Policy
         is_exempt(host) {
-          exemption := input.parameters.exemptions[_]
-          glob.match(exemption, [], host)
+        	exemption := input.parameters.exemptions[_]
+        	glob.match(exemption, [], host)
         }
 
         # Exemptions for hosts within the namespace
         is_exempt(host) {
-          glob.match(concat(".", ["*", input.review.object.metadata.namespace, "svc**"]), [], host)
+        	glob.match(concat(".", ["*", input.review.object.metadata.namespace, "svc**"]), [], host)
         }
 
         # Host and path is permitted
         is_allowed(host, path) {
-          allowedHost := allowedHosts[_]
+        	allowedHost := allowedHosts[_]
 
-          host == allowedHost.host
-          startswith(lower(path), allowedHost.path)
+        	host == allowedHost.host
+        	startswith(lower(path), allowedHost.path)
         }
 
         # Host and path is permitted for VirtualServices regex match
         # Regex must start with an allowed path in the form of "^$PATH*"
         is_allowed(host, path) {
-          allowedHost := allowedHosts[_]
+        	allowedHost := allowedHosts[_]
 
-          host == allowedHost.host
-          startswith(path, concat("", ["^", allowedHost.path]))
+        	host == allowedHost.host
+        	startswith(path, concat("", ["^", allowedHost.path]))
         }
 
         # Determines if a host and path combination is invalid and returns a concatenated response.
         is_invalid(host, path) = invalid {
+        	# Check if the hostname is exempt
+        	not is_exempt(host)
 
-          # Check if the hostname is exempt
-          not is_exempt(host)
+        	# Check if the hostname is allowed
+        	not is_allowed(host, path)
 
-          # Check if the hostname is allowed
-          not is_allowed(host, path)
-
-          invalid := concat("", [host, path])
+        	invalid := concat("", [host, path])
         }
 
         get_paths = paths {
-          count(({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) > 0
-          paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
+        	count(({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) > 0
+        	paths := ({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}
         }
 
         get_paths = paths {
-          count(({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) == 0
-          paths := ["/"]
+        	count(({path | path := input.review.object.spec.rules[_].http.paths[_].path} | ({path | path := input.review.object.spec.http[_].match[_].uri.exact} | {path | path := input.review.object.spec.http[_].match[_].uri.prefix})) | {path | path := input.review.object.spec.http[_].match[_].uri.regex}) == 0
+        	paths := ["/"]
         }
 
         get_hosts = hosts {
-          count({host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}) > 0
-          hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
+        	count({host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}) > 0
+        	hosts := {host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}
         }
 
         get_hosts = hosts {
-          count({host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}) == 0
-          hosts := [""]
+        	count({host | host := input.review.object.spec.rules[_].host} | {host | host := input.review.object.spec.hosts[_]}) == 0
+        	hosts := [""]
         }
 
         # Ingress or VirtualService must have valid hostpaths
         violation[{"msg": msg}] {
-          kind := input.review.kind.kind
-          re_match("^(Ingress|VirtualService)$", kind)
-          re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
+        	kind := input.review.kind.kind
+        	re_match("^(Ingress|VirtualService)$", kind)
+        	re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
 
-          # Gather all invalid host and path combinations
-          invalid_hostpaths := {hostpath |
-            host := get_hosts()[_]
-            path := get_paths()[_]
+        	# Gather all invalid host and path combinations
+        	invalid_hostpaths := {hostpath |
+        		host := get_hosts()[_]
+        		path := get_paths()[_]
 
-            hostpath := is_invalid(host, path)
-          }
+        		hostpath := is_invalid(host, path)
+        	}
 
-          count(invalid_hostpaths) > 0
+        	count(invalid_hostpaths) > 0
 
-          msg := sprintf("hostpaths in the %v are not valid for this namespace: %v. %s", [kind, invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
+        	msg := sprintf("hostpaths in the %v are not valid for this namespace: %v. %s", [kind, invalid_hostpaths, input.parameters.errorMsgAdditionalDetails])
         }
 
         # Hostname conflict with other namespace Ingress(es) or VirtualService(s) and hostpath not allowed
         violation[{"msg": msg}] {
-          kind := input.review.kind.kind
-          re_match("^(Ingress|VirtualService)$", kind)
-          re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
+        	kind := input.review.kind.kind
+        	re_match("^(Ingress|VirtualService)$", kind)
+        	re_match("^(networking.k8s.io|networking.istio.io)$", input.review.kind.group)
 
-          host := get_hosts()[_]
-          path := get_paths()[_]
+        	host := get_hosts()[_]
+        	path := get_paths()[_]
 
-          not is_allowed(host, path)
+        	not is_allowed(host, path)
 
-          ingress_conflicts := {output |
-            conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]
-            conflict.spec.rules[_].host == host
-            conflict.metadata.namespace != input.review.object.metadata.namespace
-            output := concat("/", ["Ingress", other_namespace, other_name])
-          }
+        	ingress_conflicts := {output |
+        		conflict := data.inventory.namespace[other_namespace]["networking.k8s.io/v1"].Ingress[other_name]
+        		conflict.spec.rules[_].host == host
+        		conflict.metadata.namespace != input.review.object.metadata.namespace
+        		output := concat("/", ["Ingress", other_namespace, other_name])
+        	}
 
-          vs_conflicts := {output |
-            conflict := data.inventory.namespace[other_namespace]["networking.istio.io/v1beta1"].VirtualService[other_name]
-            conflict.spec.hosts[_] == host
-            conflict.metadata.namespace != input.review.object.metadata.namespace
-            output := concat("/", ["VirtualService", other_namespace, other_name])
-          }
+        	vs_conflicts := {output |
+        		conflict := data.inventory.namespace[other_namespace]["networking.istio.io/v1beta1"].VirtualService[other_name]
+        		conflict.spec.hosts[_] == host
+        		conflict.metadata.namespace != input.review.object.metadata.namespace
+        		output := concat("/", ["VirtualService", other_namespace, other_name])
+        	}
 
-          conflicts := ingress_conflicts | vs_conflicts
+        	conflicts := ingress_conflicts | vs_conflicts
 
-          count(conflicts) > 0
-          msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
+        	count(conflicts) > 0
+        	msg := sprintf("%v hostname %v conflicts with existing object(s) in other namespace(s): %v. %s", [kind, host, conflicts, input.parameters.errorMsgAdditionalDetails])
         }


### PR DESCRIPTION
One violation to rule them all! Well, actually two:
* Validation for Ingresses and VirtualServices with or without hosts and/or paths
* Hostname conflict check for Ingresses and VirtualServices with or without hosts and/or paths

To do (feel free to jump in):
* Test case(s) for hostless VirtualServices
* Any quick/obvious ideas to tighten up the `get` functions further? I'm wondering if there's a way around repeating the unions.

We talked about doing this later on (and we can still deploy the previous version and look at this later) but I got the lightbulb moment the second after I said I'm heading off 😆 