### PR TITLE
DRAFT: @cbrown/1335 non employee rbac

### DIFF
--- a/general/deny-external-users/README.md
+++ b/general/deny-external-users/README.md
@@ -6,13 +6,9 @@ Checks labels set in Profile to allow RoleBindings and AuthorizationPolicy objec
 
 ### Label Set in Profile
 
-`feature.aaw.statcan.gc.ca/employee-only: "true"` --> deny
+`state.aaw.statcan.gc.ca/has-sas-notebook-feature: "true"` --> deny
 
-`state.aaw.statcan.gc.ca/employee-only-features: "true"` --> deny
-
-`feature.aaw.statcan.gc.ca/employee-only: "false"` --> allow
-
-`state.aaw.statcan.gc.ca/employee-only-features: "false"` --> allow
+`state.aaw.statcan.gc.ca/has-sas-notebook-feature: "false"` --> allow
 
 If the label is not set in the Profile, the fallthrough/default is to allow.
 
@@ -24,12 +20,12 @@ If the User is an internal employee (name/email ends with an accepted domain), t
 
 alice:
 - external user
-- `feature.aaw.statcan.gc.ca/employee-only: "true"`
+- `state.aaw.statcan.gc.ca/has-sas-notebook-feature: "true"`
 - **denied**
 
 bob:
 - external user
-- `feature.aaw.statcan.gc.ca/employee-only: "false"`
+- `state.aaw.statcan.gc.ca/has-sas-notebook-feature: "false"`
 - **allowed**
 
 jo:
@@ -39,5 +35,5 @@ jo:
 
 sam:
 - internal user
-- `feature.aaw.statcan.gc.ca/employee-only: "true"`
+- `state.aaw.statcan.gc.ca/has-sas-notebook-feature: "true"`
 - **allowed** (doesn't matter if the label is present or what it's set to)

--- a/general/deny-external-users/examples/alice/profile.yaml
+++ b/general/deny-external-users/examples/alice/profile.yaml
@@ -2,7 +2,7 @@ apiVersion: kubeflow.org/v1
 kind: Profile
 metadata:
   labels:
-    feature.aaw.statcan.gc.ca/employee-only: "true"
+    state.aaw.statcan.gc.ca/has-sas-notebook-feature: "true"
   name: alice
 spec:
   owner:

--- a/general/deny-external-users/examples/bob/profile.yaml
+++ b/general/deny-external-users/examples/bob/profile.yaml
@@ -2,7 +2,7 @@ apiVersion: kubeflow.org/v1
 kind: Profile
 metadata:
   labels:
-    feature.aaw.statcan.gc.ca/employee-only: "false"
+    state.aaw.statcan.gc.ca/has-sas-notebook-feature: "false"
   name: bob
 spec:
   owner:

--- a/general/deny-external-users/examples/sam/profile.yaml
+++ b/general/deny-external-users/examples/sam/profile.yaml
@@ -2,7 +2,7 @@ apiVersion: kubeflow.org/v1
 kind: Profile
 metadata:
   labels:
-    feature.aaw.statcan.gc.ca/employee-only: "true"
+    state.aaw.statcan.gc.ca/has-sas-notebook-feature: "true"
   name: sam
 spec:
   owner:

--- a/general/deny-external-users/template.yaml
+++ b/general/deny-external-users/template.yaml
@@ -53,7 +53,15 @@ spec:
           msg := sprintf("Profile %v has %v=%v", [ns, profileLabel, profile.metadata.labels[profileLabel]])
         }
 
-        # Ensure only non-internal employees are checked
+        # A user is considered an employee for this feature if one of the following is "true"
+        # (1) user has a domain ending in statcan.gc.ca or cloud.statcan.ca, or
+        # (2) user has a non-employee email, but is in an exception list of allowed users.
         isEmployee(email) {
           endswith(email, concat("@", [input.parameters.employeeDomains[_]]))
+        }
+        isEmployee(email) {
+          # TODO: need to test that this actually works - might need to refactor
+          exceptionList := data.inventory.cluster["v1"]["configmap"]["statcan-system"]["non-employee-exceptions"]["sasNotebookExceptions"]
+          # If the namespace has purpose "system", then this policy does not apply.
+          count([exceptionCase | exceptionCase := exceptionList[_]; exceptionCase == email]) > 0
         }

--- a/pod-security-policy/deny-employee-only-features/README.md
+++ b/pod-security-policy/deny-employee-only-features/README.md
@@ -2,15 +2,15 @@
 
 Applies to Pod and Notebook objects
 
-Checks `state.aaw.statcan.gc.ca/non-employee-users` label set in both Pod and Notebook objects and container image to allow/deny Pod and Notebook objects to be created
+Checks `state.aaw.statcan.gc.ca/exists-non-sas-notebook-user` label set in both Pod and Notebook objects and container image to allow/deny Pod and Notebook objects to be created
 
 ### Label Set in Pod and Notebook
 
-`state.aaw.statcan.gc.ca/non-employee-users: "true"` and SAS image --> deny
+`state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: "true"` and SAS image --> deny
 
-`state.aaw.statcan.gc.ca/non-employee-users: "true"` and non-SAS image --> allow
+`state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: "true"` and non-SAS image --> allow
 
-`state.aaw.statcan.gc.ca/non-employee-users: "false"`´ --> allow 
+`state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: "false"`´ --> allow 
 
 If the label is not set in the Pod and/or the Notebook, the fallthrough/default is to allow.
 
@@ -21,16 +21,16 @@ If the container image starts with `k8scc01covidacr.azurecr.io/sas:`, it is cons
 ## Test Cases (in examples folder)
 
 alice:
-- `state.aaw.statcan.gc.ca/non-employee-users: "true"`
+- `state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: "true"`
 - SAS image
 - **denied**
 
 bob:
-- `state.aaw.statcan.gc.ca/non-employee-users: "true"`
+- `state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: "true"`
 - non-SAS image
 - **allowed**
 
 tom:
-- `state.aaw.statcan.gc.ca/non-employee-users: "false"`
+- `state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: "false"`
 - SAS image
 - **allowed** (doesn't matter what the image is)

--- a/pod-security-policy/deny-employee-only-features/template.yaml
+++ b/pod-security-policy/deny-employee-only-features/template.yaml
@@ -18,11 +18,11 @@ spec:
           input.review.object.kind == "Pod"
           ns := input.review.object.metadata.namespace
           profile := data.inventory.cluster["kubeflow.org/v1"]["Profile"][ns]
-          profileLabel :=  profile.metadata.labels["state.aaw.statcan.gc.ca/non-employee-users"]
+          profileLabel :=  profile.metadata.labels["state.aaw.statcan.gc.ca/exists-non-sas-notebook-user"]
           profileLabel == "true"
           container := input.review.object.spec.containers[_]
           startswith(container.image, "k8scc01covidacr.azurecr.io/sas:")
-          msg := sprintf("Pod has state.aaw.statcan.gc.ca/non-employee-users=%v and container uses a SAS image %v", [profileLabel, container.image])
+          msg := sprintf("Pod has state.aaw.statcan.gc.ca/exists-non-sas-notebook-user=%v and container uses a SAS image %v", [profileLabel, container.image])
         }
 
         # Notebook Object
@@ -30,10 +30,10 @@ spec:
           input.review.object.kind == "Notebook"
           ns := input.review.object.metadata.namespace
           profile := data.inventory.cluster["kubeflow.org/v1"]["Profile"][ns]
-          profileLabel :=  profile.metadata.labels["state.aaw.statcan.gc.ca/non-employee-users"]
+          profileLabel :=  profile.metadata.labels["state.aaw.statcan.gc.ca/exists-non-sas-notebook-user"]
           profileLabel == "true"
           container := input.review.object.spec.template.spec.containers[_]
           startswith(container.image, "k8scc01covidacr.azurecr.io/sas:")
-          msg := sprintf("Notebook has state.aaw.statcan.gc.ca/non-employee-users=%v and container uses a SAS image %v", [profileLabel, container.image])
+          msg := sprintf("Notebook has state.aaw.statcan.gc.ca/exists-non-sas-notebook-user=%v and container uses a SAS image %v", [profileLabel, container.image])
         }
 


### PR DESCRIPTION
# Description

Refactor `deny-external-users` and `deny-employee-only-features` to make use of the new capability-based labels of `profiles-state-controller`. Specific changes

**deny-external-users**

- instead of checking if domain matches statcan employee domains, need to check also if the emails are in the `non-employee-exceptions` configmap.
- use new `state.aaw.statcan.gc.ca/has-sas-notebook-feature` label to determine if the namespace already has a pod with the `sas-notebook` feature.

**In summary**: if the user being added does not have a Statcan domain or is in the list of exception cases, and the user is being added to a namespace that has `state.aaw.statcan.gc.ca/has-sas-notebook-feature: true` (i.e. there is a pod with the `sas-notebook` feature enabled), then the request should be denied since a non-employee user without an exception is being added to a namespace with the `sas-notebook` feature present in at least one pod.

**deny-employee-only-features**

- same logic as before, except the label is now `state.aaw.statcan.gc.ca/exists-non-sas-notebook-user` instead of `state.aaw.statcan.gc.ca/non-employee-users`.

**In summary**: if a pod with a SAS image is being created in a namespace with `state.aaw.statcan.gc.ca/exists-non-sas-notebook-user: true`, then the request should be denied as there exists at least one user in the namespace who does not have the `sas-notebook` capability.