### PR TITLE
update(general/container-allowed-images): ephemeralContainers

### DIFF
--- a/general/container-allowed-images/template.yaml
+++ b/general/container-allowed-images/template.yaml
@@ -37,3 +37,10 @@ spec:
           not any(satisfied)
           msg := sprintf("container <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
         }
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.ephemeralContainers[_]
+          satisfied := [good | repo = input.parameters.repos[_] ; good = startswith(container.image, repo)]
+          not any(satisfied)
+          msg := sprintf("container <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
+        }


### PR DESCRIPTION
Notable Changes:

- update(genera/container-allowed-images): ensure that gatekeeper policy applies to ephemeral containers as well